### PR TITLE
'simple jsonpath' implementation and documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,4 +21,5 @@
 ## Usage
 
 - [Configuration](usage/configuration.md)
+- [Simple JSONPath](usage/simple-jsonpath.md)
 

--- a/docs/state/status.md
+++ b/docs/state/status.md
@@ -16,7 +16,7 @@ state:
     detailPath: syncStatus.detail
 ```
 
-The fields `generationPath`, `phasePath`, and `detailPath` all work in the same way: They contain the path to the field within the status where the corresponding state value should be written. The path allows only for simple map field access, accessing list elements or more complex jsonPath logic is not supported.
+The fields `generationPath`, `phasePath`, and `detailPath` all work in the same way: They contain the path to the field within the status where the corresponding state value should be written. The syntax is the 'simple JSONPath' syntax which is explained [here](../usage/simple-jsonpath.md).
 
 The configured verbosity defines which of the fields need to be provided, e.g. for verbosity `phase` no detail will be written into the state, so the field `detailPath` is not required in that case.
 

--- a/docs/usage/simple-jsonpath.md
+++ b/docs/usage/simple-jsonpath.md
@@ -1,0 +1,51 @@
+# Simple JSONPath
+
+Some fields in the K8Syncer configuration expect a reference to a specific field in a k8s manifest as a value. The syntax to specify these references is a primitive version of the JSONPath syntax:
+
+- Field names are separated by `.`. There is no preceding `.` before the first field name.
+- Only fields of objects (maps) can be referenced. Referencing an entry of a list is not possible.
+- To reference a field that contains a `.` in its name, escaping a `.` is possible via `\.`.
+- To reference a field that ends with `\`, use double escapes `\\`.
+- Escapes `\` are only evaluated if they directly precede a `.`. A `\` in the middle of a field name will be taken as is.
+
+## Examples
+
+#### Example 1
+`a.b.c`
+```yaml
+a:
+  b:
+    c <=
+```
+
+#### Example 2
+
+Use `\` to escape a `.` in the field name.
+
+`a\.b.c`
+```yaml
+a.b:
+  c <=
+```
+
+#### Example 3
+
+Use `\\` to escape a `\` preceding a `.`.
+
+`a\\.b.c`
+```yaml
+a\:
+  b:
+    c <=
+```
+
+#### Example 4
+
+Escapes are only evaluated if they directly precede a `.`.
+
+`a\a.b.c\`
+```yaml
+a\a:
+  b:
+    c\ <=
+```

--- a/pkg/state/status.go
+++ b/pkg/state/status.go
@@ -7,16 +7,15 @@ package state
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/k8syncer/pkg/utils"
 )
 
 var _ StateDisplay = &StatusStateDisplay{}
-
-const pathSeparator = "."
 
 type StatusStateDisplay struct {
 	fieldStatusPaths map[string][]string
@@ -26,9 +25,9 @@ type StatusStateDisplay struct {
 func NewStatusStateDisplay(lastSyncedGenerationPath, phasePath, detailPath string, v StateVerbosity) *StatusStateDisplay {
 	return &StatusStateDisplay{
 		fieldStatusPaths: map[string][]string{
-			STATE_FIELD_LAST_SYNCED_GENERATION.name: strings.Split(lastSyncedGenerationPath, pathSeparator),
-			STATE_FIELD_PHASE.name:                  strings.Split(phasePath, pathSeparator),
-			STATE_FIELD_DETAIL.name:                 strings.Split(detailPath, pathSeparator),
+			STATE_FIELD_LAST_SYNCED_GENERATION.name: utils.ParseSimpleJSONPath(lastSyncedGenerationPath),
+			STATE_FIELD_PHASE.name:                  utils.ParseSimpleJSONPath(phasePath),
+			STATE_FIELD_DETAIL.name:                 utils.ParseSimpleJSONPath(detailPath),
 		},
 		verbosity: v,
 	}

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Test Suite")
+}
+
+var _ = Describe("Utils Tests", func() {
+
+	Context("ParseSimpleJSONPath", func() {
+
+		It("should correctly parse a path without any escapes", func() {
+			Expect(ParseSimpleJSONPath("a.bc.d")).To(Equal([]string{"a", "bc", "d"}))
+			Expect(ParseSimpleJSONPath("a")).To(Equal([]string{"a"}))
+			Expect(ParseSimpleJSONPath("")).To(Equal([]string{}))
+		})
+
+		It("should correctly parse a path with one or more escapes", func() {
+			Expect(ParseSimpleJSONPath("a.b\\.c.d")).To(Equal([]string{"a", "b.c", "d"}))
+			Expect(ParseSimpleJSONPath("a\\")).To(Equal([]string{"a\\"}))
+			Expect(ParseSimpleJSONPath("a.b\\.c\\.d.e")).To(Equal([]string{"a", "b.c.d", "e"}))
+			Expect(ParseSimpleJSONPath("a.b\\.c\\.d.e.f\\.g")).To(Equal([]string{"a", "b.c.d", "e", "f.g"}))
+		})
+
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an implementation and documentation for the 'simple jsonpath' syntax. This syntax is used for referencing fields in k8s manifests. Currently, it is only used for the 'status' state option, but it will likely be used for other configuration too in the future, e.g. for where to get the git commit author information from.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
When configuring the fields for the 'status' state option, it is now possible to reference fields containing a `.`.
```
```doc user
There is [new documentation](docs/usage/simple-jsonpath.md) on the 'simple JSONPath' syntax, which is used in the configuration whenever fields in k8s manifests are referenced.
```
