### PR TITLE
add secondary auth option for git configuration

### DIFF
--- a/docs/storage/git.md
+++ b/docs/storage/git.md
@@ -22,6 +22,8 @@ The `subPath` field in the storage reference is expected to be a directory path 
         -----BEGIN RSA PRIVATE KEY-----
         ...
       privateKeyFile: /etc/ssh/foo/cert.key
+    secondaryAuth: # optional
+      # see auth
 ```
 
 - `url` - The git repo URL. To avoid problems with concurrency, there must only be one git storage definition for a given URL, so it has to be unique.
@@ -36,6 +38,7 @@ The `subPath` field in the storage reference is expected to be a directory path 
   - `password` - The password, if the type is `username_password`. If the type is `ssh`, the decryption key for the SSH private key must be specified here, unless it is not encrypted.
   - `privateKey` - The SSH private key as inline text. If encrypted, the decryption key must be provided via the `password` field. For type `ssh`, either `privateKey` or `privateKeyFile` must be set. The field is ignored for type `username_password`.
   - `privateKeyFile` - The path to the file containing the SSH private key. If the key is encrypted, the decryption key must be provided via the `password` field. For type `ssh`, either `privateKey` or `privateKeyFile` must be set. The field is ignored for type `username_password`.
+- `secondaryAuth` - Secondary authentication information for the git repository. If specified, a remote operation that failed due to authorization issues with the primary auth will be retried immediately with the secondary auth. If successful, no error will be thrown. 
 
 Optionally, a [filesystem configuration](filesystem.md) can be provided. If not, the filesystem default values (described in the linked documentation) are used, except that `inMemory` defaults to `true` in this case.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,6 +107,10 @@ type GitConfiguration struct {
 	Exclusive bool `json:"exclusive"`
 	// Auth contains the auth information needed to push commits to the repository.
 	Auth *GitRepoAuth `json:"auth,omitempty"`
+	// SecondaryAuth contains a second auth configuration, which is only used if the one under Auth does not work.
+	// This can be used for setups where there are always two active keys that are rotated by invalidating the primary one and promoting the secondary one to primary.
+	// +optional
+	SecondaryAuth *GitRepoAuth `json:"secondaryAuth,omitempty"`
 }
 
 // GitRepoAuth represents different possibilities to authenticate against a git repository

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -284,6 +284,9 @@ func (v *validator) validateGitRepoConfig(repoConfig *GitConfiguration, fldPath 
 	}
 
 	allErrs = append(allErrs, v.validateGitRepoAuth(repoConfig.Auth, fldPath.Child("auth"))...)
+	if repoConfig.SecondaryAuth != nil {
+		allErrs = append(allErrs, v.validateGitRepoAuth(repoConfig.SecondaryAuth, fldPath.Child("secondaryAuth"))...)
+	}
 
 	return allErrs
 }

--- a/pkg/persist/git/git_persister.go
+++ b/pkg/persist/git/git_persister.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
@@ -66,8 +67,15 @@ func New(ctx context.Context, stDef *config.StorageDefinition) (*GitPersister, e
 	if err != nil {
 		return nil, fmt.Errorf("error creating auth method from config: %w", err)
 	}
+	var gitSecondaryAuth transport.AuthMethod
+	if gitCfg.SecondaryAuth != nil {
+		gitSecondaryAuth, err = git.AuthFromConfig(gitCfg.SecondaryAuth)
+		if err != nil {
+			return nil, fmt.Errorf("error creating secondary auth method from config: %w", err)
+		}
+	}
 
-	gitRepo, err := git.NewRepo(fsp.Fs, gitCfg.URL, gitCfg.Branch, rootPath, gitAuth)
+	gitRepo, err := git.NewRepo(fsp.Fs, gitCfg.URL, gitCfg.Branch, rootPath, gitAuth, gitSecondaryAuth)
 	if err != nil {
 		return nil, fmt.Errorf("error during git repo creation: %w", err)
 	}

--- a/pkg/utils/git/git_suite_test.go
+++ b/pkg/utils/git/git_suite_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Git Wrapper Tests", func() {
 
 		// new repo with default branch 'bar'
 		branch1 := "bar"
-		repo1, err := NewRepo(osfs.OsFs, dr.RootPath, branch1, tempdir, nil)
+		repo1, err := NewRepo(osfs.OsFs, dr.RootPath, branch1, tempdir, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(repo1.Initialize(staticDiscardLogger)).To(Succeed())
 
@@ -81,7 +81,7 @@ var _ = Describe("Git Wrapper Tests", func() {
 
 		// new repo with default branch 'foobar'
 		branch2 := "foobar"
-		repo2, err := NewRepo(osfs.OsFs, dr.RootPath, branch2, tempdir, nil)
+		repo2, err := NewRepo(osfs.OsFs, dr.RootPath, branch2, tempdir, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(repo2.Initialize(staticDiscardLogger)).To(Succeed())
 
@@ -121,7 +121,7 @@ var _ = Describe("Git Wrapper Tests", func() {
 		Expect(exists).To(BeTrue(), "file '%s' should not be present on branch %s", branch2file, branch2)
 
 		// opening the existing repo from repo3 with its currently checked-out branch
-		repo4, err := NewRepo(osfs.OsFs, dr.RootPath, repo3.Branch, repo3.LocalPath, nil)
+		repo4, err := NewRepo(osfs.OsFs, dr.RootPath, repo3.Branch, repo3.LocalPath, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(repo4.Initialize(staticDiscardLogger)).To(Succeed())
 		// should be on branch "foobar", so one file should exist
@@ -144,7 +144,7 @@ var _ = Describe("Git Wrapper Tests", func() {
 
 		// opening the existing repo from repo4 with a new branch
 		branch5 := "xyz"
-		repo5, err := NewRepo(osfs.OsFs, dr.RootPath, branch5, repo4.LocalPath, nil)
+		repo5, err := NewRepo(osfs.OsFs, dr.RootPath, branch5, repo4.LocalPath, nil, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(repo5.Initialize(staticDiscardLogger)).To(Succeed())
 		// should be on branch "xyz" which is based on "bar", so one file should exist


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to provide a secondary auth for a git repo, which will be tried if there were authorization issues with the primary auth. This allows decoupling key/cert rotation and deployment of k8syncer.
```
