### PR TITLE
allow oidc trust configuration instead of kubeconfig for target cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ LINTER_VERSION ?= 1.55.2
 OCM_VERSION ?= 0.8.0
 HELM_VERSION ?= v3.13.2
 JQ_VERSION ?= 1.6
+SETUP_ENVTEST_VERSION ?= release-0.17
 
 .PHONY: localbin
 localbin:
@@ -160,9 +161,10 @@ golangci-lint: localbin ## Download golangci-lint locally if necessary. If wrong
 
 .PHONY: envtest
 envtest: localbin ## Download envtest-setup locally if necessary.
-	@test -s $(LOCALBIN)/setup-envtest || \
-	( echo "Installing setup-envtest ..."; \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest )
+	@test -s $(LOCALBIN)/setup-envtest && test -s $(LOCALBIN)/setup-envtest_version && cat $(LOCALBIN)/setup-envtest_version | grep -q $(SETUP_ENVTEST_VERSION) || \
+	( echo "Installing setup-envtest $(SETUP_ENVTEST_VERSION) ..."; \
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION) && \
+	echo $(SETUP_ENVTEST_VERSION) > $(LOCALBIN)/setup-envtest_version )
 
 .PHONY: ocm
 ocm: localbin ## Install OCM CLI if necessary.

--- a/blueprints/k8syncer/blueprint.yaml
+++ b/blueprints/k8syncer/blueprint.yaml
@@ -212,6 +212,6 @@ deployExecutions:
             - (( valid(imports.image-pull-secret) ? constants.pull-secret-name :~~ ))
           config:
             <<<: (( imports.helm-values.config || ~ ))
-            kubeconfig: (( valid(imports.target-cluster) ? imports.target-cluster.spec.config.kubeconfig :~~ ))
+            cluster: (( valid(imports.target-cluster) ? ( imports.target-cluster.spec.config || imports.target-cluster.spec ) :~~ ))
             syncConfigs: (( imports.sync-configs ))
             storageDefinitions: (( imports.storage-definitions ))

--- a/charts/k8syncer/templates/deployment.yaml
+++ b/charts/k8syncer/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if not .Values.config.kubeconfig }}
+      {{- if not (or .Values.config.kubeconfig .Values.config.cluster) }}
       serviceAccountName: k8syncer
       {{- end }}
       containers:
@@ -46,7 +46,7 @@ spec:
         - /k8syncer
         - --config=/etc/config/config.yaml
         {{- if .Values.config.kubeconfig }}
-        - --kubeconfig=/etc/config/kubeconfig
+        - --kubeconfig=/etc/config
         {{- end }}
         {{- if .Values.logging }}
         {{- if .Values.logging.verbosity }}

--- a/charts/k8syncer/templates/deployment.yaml
+++ b/charts/k8syncer/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
         command:
         - /k8syncer
         - --config=/etc/config/config.yaml
-        {{- if .Values.config.kubeconfig }}
+        {{- if or .Values.config.kubeconfig .Values.config.cluster }}
         - --kubeconfig=/etc/config
         {{- end }}
         {{- if .Values.logging }}
@@ -71,7 +71,7 @@ spec:
           sources:
           - secret:
               name: k8syncer-config
-        {{- if .Values.config.kubeconfig }}
+        {{- if or .Values.config.kubeconfig .Values.config.cluster }}
           - secret:
               name: k8syncer-target
         {{- end }}

--- a/charts/k8syncer/templates/deployment.yaml
+++ b/charts/k8syncer/templates/deployment.yaml
@@ -71,7 +71,30 @@ spec:
           sources:
           - secret:
               name: k8syncer-config
-        {{- if or .Values.config.kubeconfig .Values.config.cluster }}
+          {{- if or .Values.config.kubeconfig .Values.config.cluster }}
+          {{- if .Values.config.kubeconfig }}
           - secret:
               name: k8syncer-target
-        {{- end }}
+          {{- else }}
+          - secret:
+              name: k8syncer-target
+              items:
+              - key: host
+                path: host
+              {{- if .Values.config.cluster.caData }}
+              - key: caData
+                path: ca.crt
+              {{- end }}
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 7200
+              audience: {{ .Values.config.cluster.audience }}
+          {{- if .Values.config.cluster.caConfigMapName }}
+          - configMap:
+              name: {{ .Values.config.cluster.caConfigMapName }}
+              items:
+                key: ca.crt
+                path: ca.crt
+          {{- end }}
+          {{- end }}
+          {{- end }}

--- a/charts/k8syncer/templates/rbac.yaml
+++ b/charts/k8syncer/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.kubeconfig }}
+{{- if not (or .Values.config.kubeconfig .Values.config.cluster) }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:

--- a/charts/k8syncer/templates/secret-kubeconfig.yaml
+++ b/charts/k8syncer/templates/secret-kubeconfig.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.kubeconfig }}
+{{- if or .Values.config.kubeconfig .Values.config.cluster }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,5 +10,12 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
+  {{- if .Values.config.kubeconfig }}
   kubeconfig: {{ .Values.config.kubeconfig | b64enc }}
+  {{- else }}
+  {{- range $k, $v := .Values.config.cluster }}
+  {{ $k }}: {{ $v | b64enc }}
+  {{- end }}
+  {{- end }}
+
 {{- end }}

--- a/charts/k8syncer/templates/serviceaccount.yaml
+++ b/charts/k8syncer/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.kubeconfig }}
+{{- if not (or .Values.config.kubeconfig .Values.config.cluster) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/k8syncer/values.yaml
+++ b/charts/k8syncer/values.yaml
@@ -5,10 +5,16 @@ image:
   # - my-pull-secret
 
 config:
-  # kubeconfig: |
-  #   apiVersion: v1
-  #   clusters:
-  #   - cluster: ...
+  # cluster:
+  #   # specify either kubeconfig or host, audience, and one of caData or caConfigMapName.
+  #   kubeconfig: |
+  #     apiVersion: v1
+  #     clusters:
+  #     - cluster: ...
+  #   host: https://api.mycluster.com
+  #   audience: ...
+  #   caData: ...
+  #   caConfigMapName: ...
 
   syncConfigs:
   - id: dummyWatcher

--- a/cmd/k8syncer/app/app.go
+++ b/cmd/k8syncer/app/app.go
@@ -61,7 +61,7 @@ func (o *Options) run(ctx context.Context) error {
 		},
 		HealthProbeBindAddress: o.ProbeAddr,
 	}
-	mgr, err := ctrlrun.NewManager(ctrlrun.GetConfigOrDie(), mOpts)
+	mgr, err := ctrlrun.NewManager(o.ClusterConfig, mOpts)
 	if err != nil {
 		return fmt.Errorf("unable to setup manager: %w", err)
 	}

--- a/cmd/k8syncer/app/options.go
+++ b/cmd/k8syncer/app/options.go
@@ -5,9 +5,13 @@
 package app
 
 import (
-	goflag "flag"
+	"fmt"
+	"os"
+	"path"
 
 	flag "github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	ctrlrun "sigs.k8s.io/controller-runtime"
@@ -17,12 +21,14 @@ import (
 
 // Options describes the options to configure the Landscaper controller.
 type Options struct {
-	MetricsAddr string
-	ProbeAddr   string
-	ConfigPath  string
+	MetricsAddr       string
+	ProbeAddr         string
+	ConfigPath        string
+	ClusterConfigPath string
 
-	Log    logging.Logger
-	Config *config.K8SyncerConfiguration
+	Log           logging.Logger
+	Config        *config.K8SyncerConfiguration
+	ClusterConfig *rest.Config
 }
 
 func NewOptions() *Options {
@@ -32,10 +38,9 @@ func NewOptions() *Options {
 func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.MetricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	fs.StringVar(&o.ProbeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	fs.StringVar(&o.ConfigPath, "config", "", "specify the path to the configuration file")
+	fs.StringVar(&o.ConfigPath, "config", "", "Specify the path to the configuration file.")
+	fs.StringVar(&o.ClusterConfigPath, "kubeconfig", "", "Path to the kubeconfig file or directory containing either a kubeconfig or host, token, and ca file. Leave empty to use in-cluster config.")
 	logging.InitFlags(fs)
-
-	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 }
 
 // Complete parses all Options and flags and initializes the basic functions
@@ -64,10 +69,58 @@ func (o *Options) Complete() error {
 		return err
 	}
 
+	// load kubeconfig
+	o.ClusterConfig, err = LoadKubeconfig(o.ClusterConfigPath)
+	if err != nil {
+		return fmt.Errorf("unable to load kubeconfig: %w", err)
+	}
+
 	return nil
 }
 
 // validates the Options
 func (o *Options) validate() error {
 	return config.Validate(o.Config).ToAggregate()
+}
+
+// LoadKubeconfig loads a cluster configuration from the given path.
+// If the path points to a single file, this file is expected to contain a kubeconfig which is then loaded.
+// If the path points to a directory which contains a file named "kubeconfig", that file is used.
+// If the path points to a directory which does not contain a "kubeconfig" file, there must be "host", "token", and "ca.crt" files present,
+// which are used to configure cluster access based on an OIDC trust relationship.
+// If the path is empty, the in-cluster config is returned.
+func LoadKubeconfig(configPath string) (*rest.Config, error) {
+	if configPath == "" {
+		return rest.InClusterConfig()
+	}
+	fi, err := os.Stat(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if fi.IsDir() {
+		if kfi, err := os.Stat(path.Join(configPath, "kubeconfig")); err == nil && !kfi.IsDir() {
+			// there is a kubeconfig file in the specified folder
+			// point configPath to the kubeconfig
+			configPath = path.Join(configPath, "kubeconfig")
+		} else {
+			// no kubeconfig file present, load OIDC trust configuration
+			host, err := os.ReadFile(path.Join(configPath, "host"))
+			if err != nil {
+				return nil, fmt.Errorf("error reading host file: %w", err)
+			}
+			return &rest.Config{
+				Host:            string(host),
+				BearerTokenFile: path.Join(configPath, "token"),
+				TLSClientConfig: rest.TLSClientConfig{
+					CAFile: path.Join(configPath, "ca.crt"),
+				},
+			}, nil
+		}
+	}
+	// at this point, configPath points to a single file which is expected to contain a kubeconfig
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	return clientcmd.RESTConfigFromKubeConfig(data)
 }


### PR DESCRIPTION
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to provide access to the cluster which should be watched by specifying an OIDC trust configuration instead of a kubeconfig.
```
```breaking user
The old way of specifying a kubeconfig in the helm values und `config.kubeconfig` is deprecated. While it will still be supported for a while, the kubeconfig should be specified under `config.cluster.kubeconfig` from now on.
```
